### PR TITLE
Add extra error handling in DELETE/POST favorites

### DIFF
--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -32,6 +32,7 @@ router.post('/', (request, response) => {
   var location = request.body.location;
 
   if (!key) { return response.status(401).send({ error: 'Invalid or missing API key' }) }
+  if (!location) { return response.status(422).send({ error: "Missing required 'location' property"}) };
 
   findUser(key)
   .then(user => {
@@ -73,7 +74,7 @@ router.delete('/', (request, response) => {
           .then(response.status(204).send())
           .catch(error => response.status(500).send({ error }))
         } else {
-          response.status(401).send({ error: 'Invalid or missing API key' })
+          response.status(400).send({ error: `<${location}> not found in your favorites` })
         }
       })
     } else {

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -66,9 +66,16 @@ router.delete('/', (request, response) => {
   findUser(key)
   .then(user => {
     if (user.length) {
-      deleteFavorite(user, location)
-      .then(response.status(204).send())
-      .catch(error => response.status(500).send({ error }))
+      findFavorite(user, location)
+      .then(favorite => {
+        if (favorite.length) {
+          deleteFavorite(user, location)
+          .then(response.status(204).send())
+          .catch(error => response.status(500).send({ error }))
+        } else {
+          response.status(401).send({ error: 'Invalid or missing API key' })
+        }
+      })
     } else {
       response.status(401).send({ error: 'Invalid or missing API key' })
     }

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -65,9 +65,13 @@ router.delete('/', (request, response) => {
 
   findUser(key)
   .then(user => {
-    deleteFavorite(user, location)
-    .then(response.status(204).send())
-    .catch(error => response.status(500).send({ error }))
+    if (user.length) {
+      deleteFavorite(user, location)
+      .then(response.status(204).send())
+      .catch(error => response.status(500).send({ error }))
+    } else {
+      response.status(401).send({ error: 'Invalid or missing API key' })
+    }
   })
   .catch(error => response.status(500).send({ error }))
 })


### PR DESCRIPTION
### Summary:
#### DELETE
- Was returning 204 whether a record was deleted or not
- Now returns 400 if record not found
- Also returns 401 if invalid key is provided

#### POST
- Was not checking for location in JSON body
- Now checks for location and returns 422 if missing