### PR TITLE
Change status if requested location to delete not found from 400 to 404

### DIFF
--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -74,7 +74,7 @@ router.delete('/', (request, response) => {
           .then(response.status(204).send())
           .catch(error => response.status(500).send({ error }))
         } else {
-          response.status(400).send({ error: `<${location}> not found in your favorites` })
+          response.status(404).send({ error: `<${location}> not found in your favorites` })
         }
       })
     } else {


### PR DESCRIPTION
400 status is inappropriate because the syntax of the request was valid. 404 is most appropriate because the record was not found, even though the endpoint was valid. The error message makes it clear that it is a record not found: 
```
{
    "error": "<Example, CO> not found in your favorites"
}
```